### PR TITLE
feat: Add User Memory support and fix Docker build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ examples/local-nginx-test/tmp/
 
 # Docker build context
 docker/target/
+docker/ht-mcp-release/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/ht-mcp"]
 	path = modules/ht-mcp
-	url = git@github.com:OneGrep/ht-mcp.git
+	url = https://github.com/OneGrep/ht-mcp.git
 	branch = briancripe/http-transport

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV TZ="$TZ"
 # AMD64 stage
 FROM build-linux-amd64 AS base-amd64
 ARG TARGETARCH=amd64
-COPY modules/ht-mcp/release/latest/ht-mcp-linux-x86_64 /usr/local/bin/ht-mcp
+COPY docker/ht-mcp-release/latest/ht-mcp-linux-x86_64 /usr/local/bin/ht-mcp
 RUN chmod +x /usr/local/bin/ht-mcp && \
     file /usr/local/bin/ht-mcp && \
     ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible"
@@ -16,7 +16,7 @@ RUN chmod +x /usr/local/bin/ht-mcp && \
 # ARM64 stage  
 FROM build-linux-arm64 AS base-arm64
 ARG TARGETARCH=arm64
-COPY modules/ht-mcp/release/latest/ht-mcp-linux-aarch64 /usr/local/bin/ht-mcp
+COPY docker/ht-mcp-release/latest/ht-mcp-linux-aarch64 /usr/local/bin/ht-mcp
 RUN chmod +x /usr/local/bin/ht-mcp && \
     file /usr/local/bin/ht-mcp && \
     ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible"
@@ -75,9 +75,6 @@ RUN mkdir -p /workspace /home/node/.claude && \
   chown -R node:node /workspace /home/node/.claude
 
 WORKDIR /workspace
-
-# Copy the CLAUDE.local.md file to the workspace
-COPY docker/CLAUDE.local.md CLAUDE.local.md
 
 # Switch to non-root user for npm global packages
 USER node

--- a/justfile
+++ b/justfile
@@ -328,10 +328,35 @@ build-ht-mcp version="latest":
 
 # Docker Commands
 
+# Prepare ht-mcp binaries for Docker build
+[group('docker')]
+prepare-docker:
+    #!/usr/bin/env bash
+    echo "🔨 Preparing ht-mcp binaries for Docker build..."
+    
+    # Try to build ht-mcp, but continue if it fails (Windows builds might fail on macOS/Linux)
+    if just build-ht-mcp; then
+        echo "✅ ht-mcp build completed successfully"
+    else
+        echo "⚠️  ht-mcp build had errors (likely Windows targets), continuing with existing binaries..."
+    fi
+    
+    # Check if we have the required Linux binaries
+    if [ ! -f "modules/ht-mcp/release/latest/ht-mcp-linux-x86_64" ] || [ ! -f "modules/ht-mcp/release/latest/ht-mcp-linux-aarch64" ]; then
+        echo "❌ Required Linux binaries not found in modules/ht-mcp/release/latest/"
+        echo "   Please ensure ht-mcp-linux-x86_64 and ht-mcp-linux-aarch64 exist"
+        exit 1
+    fi
+    
+    echo "📁 Copying ht-mcp release files to docker/ht-mcp-release..."
+    rm -rf docker/ht-mcp-release
+    cp -r modules/ht-mcp/release docker/ht-mcp-release
+    echo "✅ Docker build preparation complete"
+
 # Build Docker image using buildx
 [group('docker')]
 docker-bake:
-    @docker buildx bake -f docker/docker-bake.hcl
+    @docker buildx bake -f docker/docker-bake.hcl --no-cache
 
 # Test Docker setup
 [group('docker')]

--- a/scripts/run-with-ht-mcp.sh
+++ b/scripts/run-with-ht-mcp.sh
@@ -100,4 +100,4 @@ if [[ -n "$DEBUG" ]]; then
     echo ""
 fi
 
-../target/release/claude-task run ${DEBUG} ${APPROVAL} --ht-mcp-port "$PORT" "$PROMPT"
+../target/release/claude-task run ${DEBUG} ${APPROVAL} "$PROMPT"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,0 +1,11 @@
+/// Bundled assets for Claude Task
+/// This module contains files that are embedded into the binary at compile time
+
+/// The CLAUDE.md content that will be written to ~/.claude/CLAUDE.md during setup
+/// This provides User Memory instructions for Claude Code when running in the container
+pub const CLAUDE_MD: &str = include_str!("assets/CLAUDE.md");
+
+/// Get the CLAUDE.md content that should be written during setup
+pub fn get_claude_md_content() -> &'static str {
+    CLAUDE_MD
+}

--- a/src/assets/CLAUDE.md
+++ b/src/assets/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+INSTRUCTIONS PRIOR TO READING AND EXECUTING ANY PROMPTS:
+
+1. Remember that you are NOT allowed to use your internal tools for terminal access, such as Bash(), LS(), or Grep().
+2. Immediately open a single session with 'ht-mcp' tools and note the session-id. You will use this session-id for the entire session unless it fails for some reason and you need to create a new one (you should only have one open at a time).
+3. ALWAYS use the 'use web server' flag set to true when creating a session.
+
+## Explanation of reasons for instructions:
+
+It is CRITICAL that you MUST use the 'ht-mcp' tools for ALL interaction with a local terminal. You do NOT have permission to use your built-in tools such as Bash(), LS(), or Grep() to execute commands.
+
+HT-MCP is a "headless terminal" that simulates the experience a human sees, especially for terminal applications that function as a 'screen'. By using this instead you get a better view of certain terminal applications.
+
+An additional critical reason you are to ALWAYS use the 'ht-mcp' tools, is that it allows humans to see what commands you execute via a Web View. You must ALWAYS set the "use web server" flag to "true" if that option is provided in an 'ht-mcp' tool. The user cannot see what you are doing unless you provide this web view.

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -3,6 +3,7 @@ use keyring::Entry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use super::assets;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OAuthAccount {
@@ -169,6 +170,14 @@ pub async fn setup_credentials_and_config(task_base_home_dir: &str, debug: bool)
     fs::write(&config_path, filtered_json).context("Failed to write filtered config file")?;
 
     println!("✓ Filtered claude config written to {config_path}");
+
+    // Write the CLAUDE.md file to the claude directory
+    let claude_md_path = format!("{claude_dir}/CLAUDE.md");
+    let claude_md_content = assets::get_claude_md_content();
+    fs::write(&claude_md_path, claude_md_content)
+        .with_context(|| format!("Failed to write CLAUDE.md to {claude_md_path}"))?;
+    
+    println!("✓ CLAUDE.md written to {claude_md_path}");
 
     // Note: MCP configuration is now handled dynamically in the container
     // using 'claude mcp add-json' commands instead of static files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod assets;
 pub mod permission;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 // Include the generated MCP help text
 include!(concat!(env!("OUT_DIR"), "/mcp_help.rs"));
 
+mod assets;
 mod credentials;
 mod docker;
 mod mcp;


### PR DESCRIPTION
## Summary

- Adds User Memory support through CLAUDE.md that instructs Claude Code to use ht-mcp tools exclusively
- Fixes Docker build issues by properly handling ht-mcp binary preparation
- Improves build reliability and compatibility

## Changes

### User Memory Support
- Added `src/assets.rs` module to bundle CLAUDE.md content into the binary
- Created `src/assets/CLAUDE.md` with instructions for Claude Code to:
  - Always use ht-mcp tools instead of built-in terminal tools
  - Always enable web server for visibility
  - Maintain single session throughout interaction
- Updated `credentials.rs` to write CLAUDE.md to `~/.claude/CLAUDE.md` during setup

### Docker Build Fixes
- Changed `.gitmodules` to use HTTPS URL instead of SSH for better compatibility
- Updated Dockerfile to copy ht-mcp binaries from `docker/ht-mcp-release/` instead of submodule
- Added `prepare-docker` just command to handle binary preparation
- Added `--no-cache` flag to docker-bake for cleaner builds
- Updated `.gitignore` to exclude `docker/ht-mcp-release/`

### Other Improvements
- Removed hardcoded `--ht-mcp-port` from `run-with-ht-mcp.sh` (now uses dynamic allocation)
- Updated `lib.rs` to expose assets module

## Test Plan

- [x] Build project with `just build`
- [x] Run `just prepare-docker` to prepare binaries
- [x] Build Docker image with `just docker-bake`
- [x] Run setup to verify CLAUDE.md is written correctly
- [x] Test running a task to ensure ht-mcp integration works

🤖 Generated with [Claude Code](https://claude.ai/code)