### PR TITLE
feat: make ht-mcp optional in Docker builds and runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,7 @@ examples/local-nginx-test/tmp/
 
 # Docker build context
 docker/target/
-docker/ht-mcp-release/
+
+# ht-mcp binaries (keep .gitkeep only)
+docker/ht-mcp-release/*
+!docker/ht-mcp-release/.gitkeep

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,18 +8,56 @@ ENV TZ="$TZ"
 # AMD64 stage
 FROM build-linux-amd64 AS base-amd64
 ARG TARGETARCH=amd64
-COPY docker/ht-mcp-release/latest/ht-mcp-linux-x86_64 /usr/local/bin/ht-mcp
-RUN chmod +x /usr/local/bin/ht-mcp && \
-    file /usr/local/bin/ht-mcp && \
-    ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible"
+ARG INCLUDE_HT_MCP=false
+
+# Always copy the ht-mcp-release directory (contains .gitkeep when empty)
+COPY docker/ht-mcp-release/ /tmp/ht-mcp-source/
+
+# Install ht-mcp if requested and binary is available
+RUN if [ "$INCLUDE_HT_MCP" = "true" ]; then \
+      if [ -f "/tmp/ht-mcp-source/latest/ht-mcp-linux-x86_64" ]; then \
+        echo "Installing ht-mcp for AMD64..." && \
+        cp /tmp/ht-mcp-source/latest/ht-mcp-linux-x86_64 /usr/local/bin/ht-mcp && \
+        chmod +x /usr/local/bin/ht-mcp && \
+        file /usr/local/bin/ht-mcp && \
+        (ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible") && \
+        echo "ht-mcp binary installed successfully for AMD64"; \
+      else \
+        echo "ERROR: INCLUDE_HT_MCP=true but ht-mcp binary not found!"; \
+        echo "Please run 'just prepare-docker-with-ht-mcp' first"; \
+        exit 1; \
+      fi; \
+    else \
+      echo "Skipping ht-mcp installation (INCLUDE_HT_MCP=$INCLUDE_HT_MCP)"; \
+    fi && \
+    rm -rf /tmp/ht-mcp-source
 
 # ARM64 stage  
 FROM build-linux-arm64 AS base-arm64
 ARG TARGETARCH=arm64
-COPY docker/ht-mcp-release/latest/ht-mcp-linux-aarch64 /usr/local/bin/ht-mcp
-RUN chmod +x /usr/local/bin/ht-mcp && \
-    file /usr/local/bin/ht-mcp && \
-    ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible"
+ARG INCLUDE_HT_MCP=false
+
+# Always copy the ht-mcp-release directory (contains .gitkeep when empty)
+COPY docker/ht-mcp-release/ /tmp/ht-mcp-source/
+
+# Install ht-mcp if requested and binary is available
+RUN if [ "$INCLUDE_HT_MCP" = "true" ]; then \
+      if [ -f "/tmp/ht-mcp-source/latest/ht-mcp-linux-aarch64" ]; then \
+        echo "Installing ht-mcp for ARM64..." && \
+        cp /tmp/ht-mcp-source/latest/ht-mcp-linux-aarch64 /usr/local/bin/ht-mcp && \
+        chmod +x /usr/local/bin/ht-mcp && \
+        file /usr/local/bin/ht-mcp && \
+        (ldd /usr/local/bin/ht-mcp || echo "Binary is statically linked or incompatible") && \
+        echo "ht-mcp binary installed successfully for ARM64"; \
+      else \
+        echo "ERROR: INCLUDE_HT_MCP=true but ht-mcp binary not found!"; \
+        echo "Please run 'just prepare-docker-with-ht-mcp' first"; \
+        exit 1; \
+      fi; \
+    else \
+      echo "Skipping ht-mcp installation (INCLUDE_HT_MCP=$INCLUDE_HT_MCP)"; \
+    fi && \
+    rm -rf /tmp/ht-mcp-source
 
 # Final stage
 FROM base-${TARGETARCH} AS base

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -2,12 +2,35 @@ group "default" {
   targets = ["claude-task-linux"]
 }
 
+group "with-ht-mcp" {
+  targets = ["claude-task-linux-with-ht-mcp"]
+}
+
+# Default target - without ht-mcp (lightweight)
 target "claude-task-linux" {
   context = "."
   dockerfile = "docker/Dockerfile"
+  args = {
+    INCLUDE_HT_MCP = "false"
+  }
   tags = [
     "claude-task:latest",
     "claude-task:${DOCKER_TAG}"
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+  output = ["type=docker"]
+}
+
+# Target with ht-mcp included
+target "claude-task-linux-with-ht-mcp" {
+  context = "."
+  dockerfile = "docker/Dockerfile"
+  args = {
+    INCLUDE_HT_MCP = "true"
+  }
+  tags = [
+    "claude-task:latest-with-ht-mcp",
+    "claude-task:${DOCKER_TAG}-with-ht-mcp"
   ]
   platforms = ["linux/amd64", "linux/arm64"]
   output = ["type=docker"]

--- a/docker/ht-mcp-release/.gitkeep
+++ b/docker/ht-mcp-release/.gitkeep
@@ -1,0 +1,1 @@
+This directory holds ht-mcp binaries when built. See 'just prepare-docker-with-ht-mcp'

--- a/justfile
+++ b/justfile
@@ -333,9 +333,17 @@ build-ht-mcp version="latest":
 
 # Docker Commands
 
-# Prepare ht-mcp binaries for Docker build
+# Prepare Docker build (default: without ht-mcp)
 [group('docker')]
 prepare-docker:
+    @echo "🔨 Preparing Docker build (without ht-mcp)..."
+    @echo "ℹ️  For lightweight Docker images, ht-mcp binaries are not included by default"
+    @echo "   Use 'just prepare-docker-with-ht-mcp' if you need ht-mcp functionality"
+    @echo "✅ Docker build preparation complete (no ht-mcp binaries needed)"
+
+# Prepare Docker build with ht-mcp binaries included
+[group('docker')]
+prepare-docker-with-ht-mcp:
     #!/usr/bin/env bash
     echo "🔨 Preparing ht-mcp binaries for Docker build..."
     
@@ -356,12 +364,17 @@ prepare-docker:
     echo "📁 Copying ht-mcp release files to docker/ht-mcp-release..."
     rm -rf docker/ht-mcp-release
     cp -r modules/ht-mcp/release docker/ht-mcp-release
-    echo "✅ Docker build preparation complete"
+    echo "✅ Docker build preparation complete (with ht-mcp binaries)"
 
-# Build Docker image using buildx
+# Build Docker image using buildx (default: without ht-mcp)
 [group('docker')]
 docker-bake:
     @docker buildx bake -f docker/docker-bake.hcl --no-cache
+
+# Build Docker image with ht-mcp included
+[group('docker')]
+docker-bake-with-ht-mcp:
+    @docker buildx bake -f docker/docker-bake.hcl with-ht-mcp --no-cache
 
 # Test Docker setup
 [group('docker')]

--- a/src/assets/CLAUDE.md
+++ b/src/assets/CLAUDE.md
@@ -2,14 +2,33 @@
 
 INSTRUCTIONS PRIOR TO READING AND EXECUTING ANY PROMPTS:
 
-1. Remember that you are NOT allowed to use your internal tools for terminal access, such as Bash(), LS(), or Grep().
-2. Immediately open a single session with 'ht-mcp' tools and note the session-id. You will use this session-id for the entire session unless it fails for some reason and you need to create a new one (you should only have one open at a time).
-3. ALWAYS use the 'use web server' flag set to true when creating a session.
+First, check if HT-MCP tools are available in this environment:
 
-## Explanation of reasons for instructions:
+1. Try to list the available MCP servers by running `claude mcp list` or check if 'ht-mcp' tools are available
+2. If HT-MCP tools are available and functional:
+   - You are NOT allowed to use your internal tools for terminal access, such as Bash(), LS(), or Grep()
+   - Immediately open a single session with 'ht-mcp' tools and note the session-id
+   - Use this session-id for the entire session unless it fails (you should only have one open at a time)
+   - ALWAYS use the 'use web server' flag set to true when creating a session
+   - Follow the HT-MCP guidelines below
+3. If HT-MCP tools are NOT available or non-functional:
+   - You may use your built-in tools such as Bash(), LS(), or Grep() for terminal interaction
+   - Proceed with normal Claude Code operation using built-in tools
+   - Inform the user that HT-MCP is not available but tasks can still be completed
 
-It is CRITICAL that you MUST use the 'ht-mcp' tools for ALL interaction with a local terminal. You do NOT have permission to use your built-in tools such as Bash(), LS(), or Grep() to execute commands.
+## HT-MCP Guidelines (when HT-MCP is available)
+
+It is CRITICAL that you MUST use the 'ht-mcp' tools for ALL interaction with a local terminal when HT-MCP is available and functional. You do NOT have permission to use your built-in tools such as Bash(), LS(), or Grep() to execute commands in this case.
 
 HT-MCP is a "headless terminal" that simulates the experience a human sees, especially for terminal applications that function as a 'screen'. By using this instead you get a better view of certain terminal applications.
 
-An additional critical reason you are to ALWAYS use the 'ht-mcp' tools, is that it allows humans to see what commands you execute via a Web View. You must ALWAYS set the "use web server" flag to "true" if that option is provided in an 'ht-mcp' tool. The user cannot see what you are doing unless you provide this web view.
+An additional critical reason you are to use the 'ht-mcp' tools when available, is that it allows humans to see what commands you execute via a Web View. You must ALWAYS set the "use web server" flag to "true" if that option is provided in an 'ht-mcp' tool. The user cannot see what you are doing unless you provide this web view.
+
+## Fallback Operation (when HT-MCP is not available)
+
+When HT-MCP tools are not available or non-functional, you should:
+
+- Use your built-in tools (Bash, LS, Grep, etc.) normally
+- Inform the user that HT-MCP web monitoring is not available
+- Complete tasks using standard Claude Code functionality
+- Provide clear terminal output and explanations of commands being run

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -89,6 +89,7 @@ pub struct RunTaskOptions {
     pub debug: Option<bool>,
     pub mcp_config: Option<String>,
     pub web_view_proxy_port: Option<u16>,
+    pub ht_mcp_port: Option<u16>,
 }
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
@@ -317,6 +318,10 @@ impl ClaudeTaskMcpServer {
         cmd_args.push("--yes".to_string()); // Skip confirmation in MCP
         if let Some(port) = args.web_view_proxy_port {
             cmd_args.push("--web-view-proxy-port".to_string());
+            cmd_args.push(port.to_string());
+        }
+        if let Some(port) = args.ht_mcp_port {
+            cmd_args.push("--ht-mcp-port".to_string());
             cmd_args.push(port.to_string());
         }
         self.add_global_options(&mut cmd_args, &args.global_options);

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -256,7 +256,8 @@ fn test_config_cli_args_override() -> Result<()> {
         "globalOptionDefaults": {
             "debug": true,
             "openEditorAfterCreate": false,
-            "buildImageBeforeRun": false
+            "buildImageBeforeRun": false,
+            "requireHtMcp": false
         }
     }"#;
 


### PR DESCRIPTION
## Summary

This PR makes ht-mcp completely optional in the claude-task project, addressing the complexity of managing it for simple use cases.

## Changes

### Docker Build System
- Added `INCLUDE_HT_MCP` build argument (default: `false`) for conditional inclusion
- Created `docker/ht-mcp-release/.gitkeep` to prevent COPY failures when binaries aren't present
- Added separate docker-bake targets: default (lightweight) and `with-ht-mcp`
- Updated justfile with `prepare-docker` and `prepare-docker-with-ht-mcp` commands

### Configuration & Validation
- Added `require_ht_mcp` boolean to GlobalOptionDefaults (default: `false`)
- Added `--require-ht-mcp` CLI flag to override config setting
- Added `check_ht_mcp_availability()` function to validate binary presence
- Added `ht_mcp_port` parameter to MCP server `run_task` tool

### Runtime Behavior
- Updated `entrypoint.sh` to gracefully handle missing ht-mcp binary
- Skip nginx proxy setup when ht-mcp not available
- Added validation for `web_view_proxy_port` requiring ht-mcp
- Provide clear error messages based on `require_ht_mcp` setting

### Documentation
- Updated `CLAUDE.md` with conditional instructions
- Check ht-mcp availability before enforcing usage
- Provide fallback guidance for standard Claude Code operation

## Usage

**Default (Lightweight) Build:**
```bash
just prepare-docker
just docker-bake
# Creates lightweight image without ht-mcp
```

**With HT-MCP Build:**
```bash
just prepare-docker-with-ht-mcp
just docker-bake-with-ht-mcp
# Creates full-featured image with ht-mcp
```

**Configuration Options:**
```bash
# Require ht-mcp for new tasks
claude-task --require-ht-mcp run "Your prompt"

# Optional ht-mcp (default)
claude-task run "Your prompt" --ht-mcp-port 3618
```

## Benefits

- **Reduced Complexity**: Simple cases work without ht-mcp overhead
- **Smaller Images**: Default Docker images are more lightweight
- **Graceful Degradation**: Missing ht-mcp doesn't break functionality
- **Clear Messaging**: Users understand what's available and what's not
- **Flexible Configuration**: Can enforce ht-mcp when needed via config/CLI

🤖 Generated with [Claude Code](https://claude.ai/code)