### PR TITLE
fix: Convert GitHub org to lowercase for Docker registry compliance

### DIFF
--- a/scripts/generate_docker_constant.sh
+++ b/scripts/generate_docker_constant.sh
@@ -2,7 +2,7 @@
 
 # Get the GitHub organization from environment variable or gh CLI
 if [ -n "$CLAUDE_TASK_DOCKER_ORG" ]; then
-    ORG="$CLAUDE_TASK_DOCKER_ORG"
+    ORG=$(echo "$CLAUDE_TASK_DOCKER_ORG" | tr '[:upper:]' '[:lower:]')
 else
     # Try to get the repository owner using gh CLI
     if command -v gh &> /dev/null; then
@@ -15,7 +15,7 @@ else
     fi
 fi
 
-# Generate the Docker image name
+# Generate the Docker image name (org is already lowercase)
 DOCKER_IMAGE="ghcr.io/${ORG}/claude-task:latest"
 
 # Create the constants file


### PR DESCRIPTION
## Summary

Fixes Docker registry error by converting organization names to lowercase.

## Problem
Docker registry names must be lowercase, but GitHub organization names can contain uppercase letters (e.g., "OneGrep"). This was causing the error:
```
ERROR: invalid tag "ghcr.io/OneGrep/claude-task:latest": repository name must be lowercase
```

## Solution
Updated the `generate_docker_constant.sh` script to convert organization names to lowercase using `tr '[:upper:]' '[:lower:]'` before constructing the Docker image name.

## Test Plan
- Run `./scripts/generate_docker_constant.sh` 
- Verify the generated constant uses lowercase org name
- Docker commands should now work without errors

🤖 Generated with [Claude Code](https://claude.ai/code)