### PR TITLE
fix: Add lowercase conversion in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,12 +81,20 @@ jobs:
           echo "DOCKER_TAG=${DOCKER_TAG}" >> $GITHUB_OUTPUT
           echo "Using Docker tag: ${DOCKER_TAG}"
 
+      - name: Determine GitHub organization (lowercase)
+        id: github_org
+        run: |
+          # Convert organization name to lowercase for Docker registry compliance
+          GITHUB_ORG=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "GITHUB_ORG=${GITHUB_ORG}" >> $GITHUB_OUTPUT
+          echo "Using GitHub org: ${GITHUB_ORG}"
+
       - name: Build Docker image
         if: github.event_name == 'pull_request'
         run: |
           VERSION=${{ steps.version.outputs.VERSION }} \
           DOCKER_TAG=${{ steps.docker_tag.outputs.DOCKER_TAG }} \
-          GITHUB_ORG=${{ github.repository_owner }} \
+          GITHUB_ORG=${{ steps.github_org.outputs.GITHUB_ORG }} \
           docker buildx bake -f docker/docker-bake.hcl claude-task-linux
 
       - name: Build and push Docker image
@@ -94,7 +102,7 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.VERSION }} \
           DOCKER_TAG=${{ steps.docker_tag.outputs.DOCKER_TAG }} \
-          GITHUB_ORG=${{ github.repository_owner }} \
+          GITHUB_ORG=${{ steps.github_org.outputs.GITHUB_ORG }} \
           docker buildx bake -f docker/docker-bake.hcl claude-task-ghcr --push
 
 


### PR DESCRIPTION
## Summary

Fixes Docker registry error in GitHub Actions by converting organization name to lowercase.

## Problem
The GitHub Actions workflow was passing the organization name directly to docker buildx bake without converting to lowercase. This caused the error:
```
ERROR: invalid tag "ghcr.io/OneGrep/claude-task:latest": repository name must be lowercase
```

## Solution
Added a new step in the workflow to convert the repository owner to lowercase before passing it to Docker commands. This ensures Docker registry compliance regardless of the GitHub organization name casing.

## Changes
- Added "Determine GitHub organization (lowercase)" step
- Updated Docker build steps to use the lowercase organization output

## Test Plan
- GitHub Actions should now successfully build and push Docker images
- Organization names with uppercase letters will be properly converted

🤖 Generated with [Claude Code](https://claude.ai/code)